### PR TITLE
Potential fix for code scanning alert no. 11: DOM text reinterpreted as HTML

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,8 @@
     "tailwindcss-animate": "^1.0.7",
     "uuid": "^11.0.3",
     "yup": "^1.4.0",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "validator": "^13.12.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",

--- a/src/components/Dashboard/Settings/General/General.tsx
+++ b/src/components/Dashboard/Settings/General/General.tsx
@@ -18,6 +18,7 @@ import {
   updateGeneralSettings,
   updateUserFields,
 } from "@/redux/features/authSlice";
+import validator from "validator";
 
 const General = () => {
   const user = useSelector((state: RootState) => state.auth.user);
@@ -94,7 +95,7 @@ const General = () => {
                 <Label>{t("settings.general.photo")}</Label>
                 <div className="mt-2">
                   <img
-                    src={user?.profilePicture}
+                    src={validator.isURL(user?.profilePicture || "") ? user?.profilePicture : ""}
                     alt="Profile"
                     className="h-16 w-16 rounded-full"
                     width={64}


### PR DESCRIPTION
Potential fix for [https://github.com/avhixorin/Medikeep-frontend/security/code-scanning/11](https://github.com/avhixorin/Medikeep-frontend/security/code-scanning/11)

To fix the problem, we need to ensure that the `profilePicture` URL is sanitized before being used in the `img` tag. This can be done by validating the URL to ensure it is a well-formed and safe URL. We can use a library like `validator` to perform this validation.

1. Install the `validator` library if it is not already installed.
2. Import the `validator` library in the `General.tsx` file.
3. Use the `validator` library to validate the `profilePicture` URL before using it in the `img` tag.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
